### PR TITLE
Fix for base glmnet not being recognised

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: FTM
 Type: Package
 Title: Flexible Transfer Models
-Version: 0.1.0
+Version: 0.1.1
 Author: Corey Giles [aut, cre],
   Changyu Yi [aut]
 Authors@R: c(person("Corey", "Giles", role = c("aut", "cre"),
@@ -22,7 +22,7 @@ Description: Provides a flexible framework for the transfer of 'omics prediction
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Imports:
     methods,
     glmnet

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,13 @@
+# FlexibleTransferModels
+# NEWS.md file to document the version history of the package.
+
+# Version 0.1.1 (2025-05-02)
+## Bug Fixes and minor features
+- Fixed a small bug that limited glmnet models to just cv.glmnet objects.
+- Added the ability to explicitly label the outcome name.
+
+# Version 0.1.0 (2024-05-29)
+## Initial Release
+- Introduced the Flexible Transfer Models (FTM) package.
+- Enabled adaptation of glm, lm, and glmnet models to the FTM framework.
+- Implemented a matrix-based approach for re-estimating model parameters.

--- a/R/createFTM.R
+++ b/R/createFTM.R
@@ -7,6 +7,7 @@
 #' @param s Optional value of the penalty parameter (lambda); applicable only for glmnet or lm models.
 #' @param x matrix of predictors used in the glmnet model.
 #' @param y vector of outcomes used in the glmnet model.
+#' @param outcome_name Optional name of the outcome variable; if not provided, it will be extracted from the model object.
 #'
 #' @return An FTM object either of type ftmglm or ftmlm depending on the input model.
 #' @export
@@ -23,16 +24,18 @@
 #' glmnet_model <- glmnet::cv.glmnet(predictors, mtcars$am, family = "binomial")
 #' ftm_object <- createFTM(glmnet_model)
 #' }
-createFTM <- function(modelObj, s = NULL, x = NULL, y = NULL) {
+createFTM <- function(modelObj, s = NULL, x = NULL, y = NULL, outcome_name = NULL) {
 
     # Determine if the model is a logistic model from glm
     if (inherits(modelObj, "glm")) {
-        return(createFromGlm(modelObj))
+        return(createFromGlm(modelObj = modelObj,
+                             outcome_name = outcome_name))
     }
 
     # Determine if the model is a linear model from lm
     if (inherits(modelObj, "lm")) {
-        return(createFromLm(modelObj))
+        return(createFromLm(modelObj = modelObj,
+                            outcome_name = outcome_name))
     }
 
     # Determine if the model is a glmnet model
@@ -41,6 +44,10 @@ createFTM <- function(modelObj, s = NULL, x = NULL, y = NULL) {
     }
 
     # Create an FTM object from glmnet model
-    return(createFromGlmnet(modelObj, s, x, y))
+    return(createFromGlmnet(modelObj = modelObj,
+                            s = s,
+                            x = x,
+                            y = y,
+                            outcome_name = outcome_name))
 }
 

--- a/R/createFTM.R
+++ b/R/createFTM.R
@@ -28,13 +28,13 @@ createFTM <- function(modelObj, s = NULL, x = NULL, y = NULL, outcome_name = NUL
 
     # Determine if the model is a logistic model from glm
     if (inherits(modelObj, "glm")) {
-        return(createFromGlm(modelObj = modelObj,
+        return(createFromGlm(glmObj = modelObj,
                              outcome_name = outcome_name))
     }
 
     # Determine if the model is a linear model from lm
     if (inherits(modelObj, "lm")) {
-        return(createFromLm(modelObj = modelObj,
+        return(createFromLm(lmObj = modelObj,
                             outcome_name = outcome_name))
     }
 
@@ -44,7 +44,7 @@ createFTM <- function(modelObj, s = NULL, x = NULL, y = NULL, outcome_name = NUL
     }
 
     # Create an FTM object from glmnet model
-    return(createFromGlmnet(modelObj = modelObj,
+    return(createFromGlmnet(glmnetObj = modelObj,
                             s = s,
                             x = x,
                             y = y,

--- a/R/createFromGlm.R
+++ b/R/createFromGlm.R
@@ -4,6 +4,7 @@
 #' It extracts the necessary components and adapts them into the FTM framework.
 #'
 #' @param glmObj a glm object from the stats package
+#' @param outcome_name Optional name of the outcome variable; if not provided, it will be extracted from the model object.
 #'
 #' @return A ftmglm object.
 #'
@@ -16,7 +17,7 @@
 #' }
 #' @export
 #' @importFrom stats formula model.matrix
-createFromGlm <- function(glmObj) {
+createFromGlm <- function(glmObj, outcome_name = NULL) {
 
     # Validation for glmObj
     if (!inherits(glmObj, "glm")) {
@@ -39,8 +40,10 @@ createFromGlm <- function(glmObj) {
     XtWz <- t(X) %*% diag(as.vector(w)) %*% z
     XtWX <- t(X) %*% diag(as.vector(w)) %*% X
 
-    # Get the outcome name
-    outcome_name <- all.vars(formula(glmObj))[1]
+    # Get the outcome name (if not provided)
+    if (is.null(outcome_name)) {
+        outcome_name <- all.vars(formula(glmObj))[1]
+    }
 
     # Update the outcome name
     colnames(XtWz) <- outcome_name

--- a/R/createFromGlmnet.R
+++ b/R/createFromGlmnet.R
@@ -131,7 +131,7 @@ createFromGlmnet <- function(glmnetObj, s = NULL, x = NULL, y = NULL, outcome_na
 
     } else {
         # Warn user that the model is not binomial or linear
-        stop(sprintf("glmnetObj must be a binomial or linear (gaussian) model. Provided model is a: %s", class(glmnetObj$glmnet.fit)[1]))
+        stop(sprintf("glmnetObj must be a binomial or linear (gaussian) model. Provided model is a: %s", class(glmnetObj)[1]))
     }
 
 }

--- a/R/createFromGlmnet.R
+++ b/R/createFromGlmnet.R
@@ -55,7 +55,7 @@ createFromGlmnet <- function(glmnetObj, s = NULL, x = NULL, y = NULL, outcome_na
     # Get the outcome variable name
     if (is.null(outcome_name)) {
         # Extract the outcome name from the column names of the response variable, or from the glmnet object
-        if (is.data.frame((y) || is.matrix(y))) {
+        if (is.data.frame(y) || is.matrix(y)) {
             outcome_name <- colnames(y)
         } else if (inherits(glmnetObj, "cv.glmnet")) {
             outcome_name <- get_outcome_name(glmnetObj$glmnet.fit)

--- a/R/createFromLm.R
+++ b/R/createFromLm.R
@@ -4,6 +4,7 @@
 #' It extracts the necessary components and adapts them into the FTM framework.
 #'
 #' @param lmObj a lm object from the stats package
+#' @param outcome_name Optional name of the outcome variable; if not provided, it will be extracted from the model object.
 #'
 #' @return A ftmlm object.
 #'
@@ -16,7 +17,7 @@
 #' }
 #' @export
 #' @importFrom stats formula model.matrix
-createFromLm <- function(lmObj) {
+createFromLm <- function(lmObj, outcome_name = NULL) {
 
     # Validation for lmObj
     if (!inherits(lmObj, "lm")) {
@@ -38,8 +39,10 @@ createFromLm <- function(lmObj) {
     Xty <- t(X) %*% y
     XtX <- t(X) %*% X
 
-    # Get the outcome name
-    outcome_name <- all.vars(formula(lmObj))[1]
+    # Get the outcome name (if not provided)
+    if (is.null(outcome_name)) {
+        outcome_name <- all.vars(formula(lmObj))[1]
+    }
 
     # Update the outcome name
     colnames(Xty) <- outcome_name

--- a/README.Rmd
+++ b/README.Rmd
@@ -95,4 +95,15 @@ browseVignettes("FTM")
 
 Contributions to the FTM package are welcome from the community. Bug reports, documentation enhancements, and feature requests can be filed on the [GitHub issues page](https://github.com/BakerMetabolomics/FlexibleTransferModels/issues).
 
+## Contact
+
+For any inquiries, please contact:
+
+- Corey Giles: Corey.Giles@Baker.edu.au
+- Changyu Yi: Joe.Yi@Baker.edu.au
+
+## Version History
+
+For a detailed list of changes, improvements, and bug fixes, please refer to the [NEWS.md](NEWS.md) file.
+
 

--- a/README.md
+++ b/README.md
@@ -84,17 +84,11 @@ show(ftmglmnet_model)
 #> Coefficients:
 #> (Intercept)           hp           wt          cyl  
 #>      6.2245       0.0116      -2.0526      -0.3230
-```
-
-``` r
 
 # Extract the beta coefficients from a FTM object
 coef(ftmglmnet_model)
 #> (Intercept)          hp          wt         cyl 
 #>  6.22451499  0.01164029 -2.05263254 -0.32296485
-```
-
-``` r
 
 
 # 3. Predict on "new" data
@@ -114,9 +108,6 @@ predictions
 #> Merc 240D         0.2903789
 #> Merc 230          0.3947689
 #> Merc 280          0.2070870
-```
-
-``` r
 
 # 4. Predict on "new" data that has missing predictors
 new_data_missing <- mtcars[1:10, c("hp", "wt")] # missing cyl
@@ -152,3 +143,15 @@ Contributions to the FTM package are welcome from the community. Bug
 reports, documentation enhancements, and feature requests can be filed
 on the [GitHub issues
 page](https://github.com/BakerMetabolomics/FlexibleTransferModels/issues).
+
+## Contact
+
+For any inquiries, please contact:
+
+- Corey Giles: <Corey.Giles@Baker.edu.au>
+- Changyu Yi: <Joe.Yi@Baker.edu.au>
+
+## Version History
+
+For a detailed list of changes, improvements, and bug fixes, please
+refer to the [NEWS.md](NEWS.md) file.

--- a/man/createFTM.Rd
+++ b/man/createFTM.Rd
@@ -4,7 +4,7 @@
 \alias{createFTM}
 \title{Create a Flexible Transfer Model (FTM) Object from Different Model Types}
 \usage{
-createFTM(modelObj, s = NULL, x = NULL, y = NULL)
+createFTM(modelObj, s = NULL, x = NULL, y = NULL, outcome_name = NULL)
 }
 \arguments{
 \item{modelObj}{A model object from glm, glmnet, or lm.}
@@ -14,6 +14,8 @@ createFTM(modelObj, s = NULL, x = NULL, y = NULL)
 \item{x}{matrix of predictors used in the glmnet model.}
 
 \item{y}{vector of outcomes used in the glmnet model.}
+
+\item{outcome_name}{Optional name of the outcome variable; if not provided, it will be extracted from the model object.}
 }
 \value{
 An FTM object either of type ftmglm or ftmlm depending on the input model.

--- a/man/createFromGlm.Rd
+++ b/man/createFromGlm.Rd
@@ -4,10 +4,12 @@
 \alias{createFromGlm}
 \title{Create a Flexible Transfer Model (ftmglm or ftmlm) from a glm object}
 \usage{
-createFromGlm(glmObj)
+createFromGlm(glmObj, outcome_name = NULL)
 }
 \arguments{
 \item{glmObj}{a glm object from the stats package}
+
+\item{outcome_name}{Optional name of the outcome variable; if not provided, it will be extracted from the model object.}
 }
 \value{
 A ftmglm object.

--- a/man/createFromGlmnet.Rd
+++ b/man/createFromGlmnet.Rd
@@ -4,7 +4,7 @@
 \alias{createFromGlmnet}
 \title{Create a Flexible Transfer Model (ftmglm or ftmlm) from a glmnet object}
 \usage{
-createFromGlmnet(glmnetObj, s = NULL, x = NULL, y = NULL)
+createFromGlmnet(glmnetObj, s = NULL, x = NULL, y = NULL, outcome_name = NULL)
 }
 \arguments{
 \item{glmnetObj}{a cv.glmnet or glmnet object from the glmnet package}
@@ -14,6 +14,8 @@ createFromGlmnet(glmnetObj, s = NULL, x = NULL, y = NULL)
 \item{x}{matrix of predictors used in the glmnet model}
 
 \item{y}{vector of outcomes used in the glmnet model}
+
+\item{outcome_name}{Optional name of the outcome variable; if not provided, it will be extracted from the model object.}
 }
 \value{
 A ftmglm or ftmlm object.
@@ -31,7 +33,7 @@ The data used in the glmnet model must be available in the global environment.
 # Fitting a glmnet model to the mtcars dataset
 data(mtcars)
 predictors <- as.matrix(mtcars[, c("hp", "wt", "cyl")])
-glmnet_model <- glmnet::cv.glmnet(predictors, mtcars$am, family = "binomial")
+glmnet_model <- glmnet::cv.glmnet(predictors, mtcars$am, family = "binomial", alpha = 0)
 ftmglm_model <- createFromGlmnet(glmnet_model, x = predictors, y = mtcars$am)
 }
 }

--- a/man/createFromLm.Rd
+++ b/man/createFromLm.Rd
@@ -4,10 +4,12 @@
 \alias{createFromLm}
 \title{Create a Flexible Transfer Model (ftmlm) from a lm object}
 \usage{
-createFromLm(lmObj)
+createFromLm(lmObj, outcome_name = NULL)
 }
 \arguments{
 \item{lmObj}{a lm object from the stats package}
+
+\item{outcome_name}{Optional name of the outcome variable; if not provided, it will be extracted from the model object.}
 }
 \value{
 A ftmlm object.


### PR DESCRIPTION
In createFromGlmnet, we were looking at glmnetObj$glmnet.fit, which only exists in cv.glmnet objects.
Now we extract that object if the input is a cv.glmnet object.

Also added some quality of life features, such as allowing explicit outcome names, which are most useful for glmnet models.